### PR TITLE
Citizens Support - /trait chatbubble

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -84,6 +84,21 @@ ChatBubble_Sound_Volume: 1.0
 #Larger numbers means the sound travels farther.
 
 ##############################
+#      Citizens Config       #
+##############################
+
+Use_ChatBubble_Trait_Citizens: true
+#The trait won't load if citizens isn't loaded anyway, this just prevents unneeded
+#Code from running if you decide not to use this trait
+Citizens_Bubbles_Require_See_Permission: false
+#Enabling this requires players to have the permission to see a Citizens ChatBubble
+Citizens_Bubbles_See_Permission: "chatbubble.see"
+#The permission needed to see Citizens ChatBubbles
+ChatBubble_Overrides_NPC_Chat: false
+#Setting this to true cancels the chat from displaying in the normal player chat and
+#Shows only ChatBubbles over their heads, useful for lobbies or towns
+
+##############################
 #          0 Config          #
 ##############################
 
@@ -136,5 +151,5 @@ ConfigFive_See_Permission: "chatbubble.see"
 #                        Version                         #
 ##########################################################
 
-VERSION: 8
+VERSION: 9
 #Do not touch this. No touchy.

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,10 +1,10 @@
 name: "ChatBubbles"
 author: TheTealViper
-version: "1.18.1.a.4"
+version: "1.18.1.a.5"
 api-version: 1.18
 description: "ChatBubbles above players' heads"
 main: me.TheTealViper.chatbubbles.ChatBubbles
-softdepend: [Factions, PlaceholderAPI, HolographicDisplays, DecentHolograms]
+softdepend: [Factions, PlaceholderAPI, HolographicDisplays, DecentHolograms, Citizens]
 commands:
   chatbubble:
     description: Main command

--- a/src/me/TheTealViper/chatbubbles/ChatBubbles.java
+++ b/src/me/TheTealViper/chatbubbles/ChatBubbles.java
@@ -14,6 +14,7 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import me.TheTealViper.chatbubbles.citizens.ChatBubbleTrait;
 import me.TheTealViper.chatbubbles.implentations.ChatListenerHIGH;
 import me.TheTealViper.chatbubbles.implentations.ChatListenerHIGHEST;
 import me.TheTealViper.chatbubbles.implentations.ChatListenerLOW;
@@ -32,11 +33,13 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 	public boolean seeOwnBubble = false;
 	public double bubbleOffset = 2.5;
 	public PluginFile togglePF;
-	private boolean foundHolographicDisplays = false;
-	private boolean foundDecentHolograms = false;
-	private HolographicDisplaysImplementation HDI;
-	private DecentHologramsImplementation DHI;
+	public boolean foundHolographicDisplays = false;
+	public boolean foundDecentHolograms = false;
+	private boolean useTrait = false;
+	public HolographicDisplaysImplementation HDI;
+	public DecentHologramsImplementation DHI;
 	public static EventPriority eventPriority;
+	private ChatBubbleTrait trait;
 	
 	public void onEnable(){
 		if(Bukkit.getServer().getPluginManager().getPlugin("HolographicDisplays") != null) {
@@ -54,6 +57,13 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 		DecentHologramsImplementation.plugin = this;
 		initVars();
 		togglePF = new PluginFile(this, "toggleData");
+		if(getServer().getPluginManager().getPlugin("Citizens") != null) {
+			if(getServer().getPluginManager().getPlugin("Citizens").isEnabled() == true && this.useTrait) {
+				Bukkit.getServer().getConsoleSender().sendMessage("[ChatBubbles] Citizens found and trait chatbubble enabled");
+				net.citizensnpcs.api.CitizensAPI.getTraitFactory().registerTrait(net.citizensnpcs.api.trait.TraitInfo.create(ChatBubbleTrait.class).withName("chatbubble"));
+				trait = new ChatBubbleTrait();
+			}					
+		}
 	}
 	
 	private void initVars() {
@@ -68,6 +78,7 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 			suffix = "";
 		seeOwnBubble = getConfig().getBoolean("ChatBubble_See_Own_Bubbles");
 		bubbleOffset = getConfig().getDouble("ChatBubble_Height_Offset");
+		useTrait = getConfig().getBoolean("Use_ChatBubble_Trait_Citizens");
 		switch(getConfig().getString("ChatBubble_EventPriority").toUpperCase()) {
 		case "HIGH":
 			eventPriority = EventPriority.HIGH;
@@ -103,6 +114,11 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 	}
 	
 	public void onDisable(){
+		if(getServer().getPluginManager().getPlugin("Citizens") != null) {
+			if(getServer().getPluginManager().getPlugin("Citizens").isEnabled() && this.useTrait) {
+				trait.onDisable();
+			}
+		}
 		getServer().getConsoleSender().sendMessage(makeColors("ChatBubbles from TheTealViper shutting down. Bshzzzzzz"));
 	}
 	

--- a/src/me/TheTealViper/chatbubbles/citizens/ChatBubbleTrait.java
+++ b/src/me/TheTealViper/chatbubbles/citizens/ChatBubbleTrait.java
@@ -1,0 +1,67 @@
+package me.TheTealViper.chatbubbles.citizens;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.plugin.java.JavaPlugin;
+import me.TheTealViper.chatbubbles.ChatBubbles;
+import net.citizensnpcs.api.ai.speech.SpeechContext;
+import net.citizensnpcs.api.ai.speech.event.NPCSpeechEvent;
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.trait.Trait;
+
+public class ChatBubbleTrait extends Trait {
+	
+	ChatBubbles plugin = null;
+	CitizensHDChatbubble hdHandler;
+	CitizensDHChatbubble dhHandler;
+	private boolean chatBubbleOverridesNPCChat = false;
+	
+	public ChatBubbleTrait() {
+		super("chatbubble");
+		plugin = JavaPlugin.getPlugin(ChatBubbles.class);
+		if(plugin.foundHolographicDisplays) {
+			hdHandler = new CitizensHDChatbubble(plugin);
+			//debug
+			plugin.getServer().getLogger().info("[ChatBubbles] " + "Initializing Citizens HolographicDisplays Handler");
+		}else if(plugin.foundDecentHolograms) {
+			dhHandler = new CitizensDHChatbubble(plugin);
+			//debug
+			plugin.getServer().getLogger().info("[ChatBubbles] " + "Initializing Citizens DecentHolograms Handler");
+		}
+		this.chatBubbleOverridesNPCChat = plugin.getConfig().getBoolean("ChatBubble_Overrides_NPC_Chat");
+	}
+	
+	@EventHandler(priority=EventPriority.LOWEST)
+	public void onNPCSpeech(NPCSpeechEvent event) {
+		if (this.npc != event.getNPC()) return;
+	    if ((event.getNPC() != null) && (event.getNPC().isSpawned())) {
+	    	NPC talker = event.getNPC();
+	    	if ((talker.getEntity() instanceof LivingEntity))
+	    	{
+	    		SpeechContext sp = event.getContext();
+	    		String msg = sp.getMessage();
+	    		LivingEntity p = (LivingEntity)talker.getEntity();
+	    		//Check which Hologram plugin is being used, then call correct method
+	    		if(plugin.foundHolographicDisplays) {
+	    			hdHandler.createBubbleHD(p, msg);
+	    		}else if(plugin.foundDecentHolograms) {
+	    			dhHandler.createBubbleDH(p, msg);
+	    		}
+	    		//create config options and set up
+	    		if(this.chatBubbleOverridesNPCChat)
+	    			event.setCancelled(true);
+	    	}
+	    }
+	}
+	
+	@Override
+	public void onAttach() {
+		plugin.getServer().getLogger().info("[ChatBubbles] " + npc.getName() + " has been assigned trait ChatBubble!");
+	}
+	
+	public void onDisable() {
+		net.citizensnpcs.api.CitizensAPI.getTraitFactory().deregisterTrait(net.citizensnpcs.api.trait.TraitInfo.create(ChatBubbleTrait.class).withName("chatbubble"));
+	}
+
+}

--- a/src/me/TheTealViper/chatbubbles/citizens/CitizensDHChatbubble.java
+++ b/src/me/TheTealViper/chatbubbles/citizens/CitizensDHChatbubble.java
@@ -1,0 +1,80 @@
+package me.TheTealViper.chatbubbles.citizens;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import eu.decentsoftware.holograms.api.DHAPI;
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import me.TheTealViper.chatbubbles.ChatBubbles;
+
+public class CitizensDHChatbubble {
+	
+	private ChatBubbles plugin;
+	private boolean requirePerm;
+	private String seePerm;
+	
+	public CitizensDHChatbubble(ChatBubbles main) {
+		this.plugin = main;
+		this.requirePerm = plugin.getConfig().getBoolean("Citizens_Bubbles_Require_See_Permission");
+		this.seePerm = plugin.getConfig().getString("Citizens_Bubbles_See_Permission");
+	}
+	
+	public void createBubbleDH(LivingEntity p, String msg) {
+		if(plugin.DHI.existingHolograms.containsKey(p.getUniqueId())) {
+			for(Hologram h : plugin.DHI.existingHolograms.get(p.getUniqueId())) {
+				if(!h.isEnabled()) {
+					h.disable();
+					h.delete();
+				}
+			}
+		}
+		final Hologram hologram = DHAPI.createHologram(System.currentTimeMillis() + "", p.getLocation().add(0.0, plugin.bubbleOffset, 0.0), false);
+		List<Hologram> hList = new ArrayList<Hologram>();
+		hList.add(hologram);
+		plugin.DHI.existingHolograms.put(p.getUniqueId(), hList);
+		hologram.hideAll();
+		//hologram.getVisibilityManager().setVisibleByDefault(false);
+		for(Player oP : Bukkit.getOnlinePlayers()){
+			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName())) 
+					&& (oP.getWorld().getName().equals(p.getWorld().getName()) 
+					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance) 
+					&& (!requirePerm || (requirePerm && oP.hasPermission(seePerm))))
+				hologram.show(oP, 0);
+				//hologram.getVisibilityManager().showTo(oP);
+		}
+		int lines = plugin.DHI.formatHologramLines(p, hologram, msg);
+
+		new BukkitRunnable() {
+			int ticksRun = 0;
+			@Override
+			public void run() {
+				ticksRun++;
+				if(hologram.isEnabled())
+					DHAPI.moveHologram(hologram, p.getLocation().add(0.0, plugin.bubbleOffset + .25 * lines, 0.0));
+				if (ticksRun > plugin.life) {
+					hologram.disable();
+					hologram.delete();
+					cancel();
+				}
+		}}.runTaskTimer(plugin, 1L, 1L);
+		
+		if(plugin.getConfig().getBoolean("ChatBubble_Play_Sound")) {
+			String sound = plugin.getConfig().getString("ChatBubble_Sound_Name").toLowerCase();
+			float volume = (float) plugin.getConfig().getDouble("ChatBubble_Sound_Volume");
+			if(!sound.equals("")) {
+				try {
+					p.getWorld().playSound(p.getLocation(), sound, volume, 1.0f);
+				}catch(Exception e) {
+					Bukkit.getServer().getConsoleSender().sendMessage("Something is wrong in your ChatBubble config.yml sound settings!");
+					Bukkit.getServer().getConsoleSender().sendMessage("Please ensure that 'ChatBubble_Sound_Name' works in a '/playsound' command test.");
+				}
+			}
+		}
+	}
+}
+    

--- a/src/me/TheTealViper/chatbubbles/citizens/CitizensHDChatbubble.java
+++ b/src/me/TheTealViper/chatbubbles/citizens/CitizensHDChatbubble.java
@@ -1,0 +1,79 @@
+package me.TheTealViper.chatbubbles.citizens;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import com.gmail.filoghost.holographicdisplays.api.Hologram;
+import com.gmail.filoghost.holographicdisplays.api.HologramsAPI;
+
+import me.TheTealViper.chatbubbles.ChatBubbles;
+
+@SuppressWarnings("deprecation")
+//Should probably update all HD classes at some point to conform with new methods
+public class CitizensHDChatbubble {
+	
+	private ChatBubbles plugin;
+	private boolean requirePerm;
+	private String seePerm;
+	
+	public CitizensHDChatbubble(ChatBubbles main) {
+		this.plugin = main;
+		this.requirePerm = plugin.getConfig().getBoolean("Citizens_Bubbles_Require_See_Permission");
+		this.seePerm = plugin.getConfig().getString("Citizens_Bubbles_See_Permission");
+	}
+	
+	public void createBubbleHD(LivingEntity p, String msg) {
+		if(plugin.HDI.existingHolograms.containsKey(p.getUniqueId())) {
+			for(Hologram h : plugin.HDI.existingHolograms.get(p.getUniqueId())) {
+				if(!h.isDeleted())
+					h.delete();
+			}
+		}
+		final Hologram hologram = HologramsAPI.createHologram(plugin, p.getLocation().add(0.0, plugin.bubbleOffset, 0.0));
+		List<Hologram> hList = new ArrayList<Hologram>();
+		hList.add(hologram);
+		plugin.HDI.existingHolograms.put(p.getUniqueId(), hList);
+		hologram.getVisibilityManager().setVisibleByDefault(false);
+		for(Player oP : Bukkit.getOnlinePlayers()){
+			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName())) 
+					&& (oP.getWorld().getName().equals(p.getWorld().getName()) 
+					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance) 
+					&& (!requirePerm || (requirePerm && oP.hasPermission(seePerm)))
+					&& oP.canSee(p))
+				hologram.getVisibilityManager().showTo(oP);
+		}
+		int lines = plugin.HDI.formatHologramLines(p, hologram, msg);
+
+		new BukkitRunnable() {
+			int ticksRun = 0;
+			@Override
+			public void run() {
+				ticksRun++;
+				if(!hologram.isDeleted())
+					hologram.teleport(p.getLocation().add(0.0, plugin.bubbleOffset + .25 * lines, 0.0));
+				if (ticksRun > plugin.life) {
+					hologram.delete();
+					cancel();
+				}
+		}}.runTaskTimer(plugin, 1L, 1L);
+		
+		if(plugin.getConfig().getBoolean("ChatBubble_Play_Sound")) {
+			String sound = plugin.getConfig().getString("ChatBubble_Sound_Name").toLowerCase();
+			float volume = (float) plugin.getConfig().getDouble("ChatBubble_Sound_Volume");
+			if(!sound.equals("")) {
+				try {
+					p.getWorld().playSound(p.getLocation(), sound, volume, 1.0f);
+				}catch(Exception e) {
+					Bukkit.getServer().getConsoleSender().sendMessage("Something is wrong in your ChatBubble config.yml sound settings!");
+					Bukkit.getServer().getConsoleSender().sendMessage("Please ensure that 'ChatBubble_Sound_Name' works in a '/playsound' command test.");
+				}
+			}
+		}
+	}
+}
+    

--- a/src/me/TheTealViper/chatbubbles/implentations/DecentHologramsImplementation.java
+++ b/src/me/TheTealViper/chatbubbles/implentations/DecentHologramsImplementation.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -20,7 +21,7 @@ import net.md_5.bungee.api.ChatColor;
 
 public class DecentHologramsImplementation {
 	public static ChatBubbles plugin;
-	private Map<UUID, List<Hologram>> existingHolograms = new HashMap<UUID, List<Hologram>>();
+	public Map<UUID, List<Hologram>> existingHolograms = new HashMap<UUID, List<Hologram>>();
 	
 	public void handleZero(String message, Player p){
 		boolean requirePerm = plugin.getConfig().getBoolean("ConfigZero_Require_Permissions");
@@ -361,12 +362,12 @@ public class DecentHologramsImplementation {
 		}
 	}
 	
-	public int formatHologramLines(Player p, Hologram hologram, String message){
+	public int formatHologramLines(LivingEntity e, Hologram hologram, String message){
 		List<String> lineList = new ArrayList<String>();
 		for(String formatLine : plugin.getConfig().getStringList("ChatBubble_Message_Format")){
 			boolean addedToLine = false;
 			if(Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI"))
-				formatLine = placeholderShit.formatString(p, formatLine);
+				formatLine = placeholderShit.formatString(e, formatLine);
 			if(formatLine.contains("%chatbubble_message%")){
 				addedToLine = true;
 				formatLine = formatLine.replace("%chatbubble_message%", message);
@@ -406,7 +407,7 @@ public class DecentHologramsImplementation {
 						s = ChatBubbles.makeColors(s);
 						if(plugin.getConfig().getBoolean("ChatBubble_Strip_Formatting"))
 							s = ChatColor.stripColor(s);
-						s = placeholderShit.formatString(p, plugin.prefix + s + plugin.suffix);
+						s = placeholderShit.formatString(e, plugin.prefix + s + plugin.suffix);
 						s = ChatBubbles.makeColors(s);
 						lineList.add(s);
 					} else {
@@ -423,7 +424,7 @@ public class DecentHologramsImplementation {
 					formatLine = ChatBubbles.makeColors(formatLine);
 					if(plugin.getConfig().getBoolean("ChatBubble_Strip_Formatting"))
 						formatLine = ChatColor.stripColor(formatLine);
-					formatLine = placeholderShit.formatString(p, plugin.prefix + formatLine + plugin.suffix);
+					formatLine = placeholderShit.formatString(e, plugin.prefix + formatLine + plugin.suffix);
 					formatLine = ChatBubbles.makeColors(formatLine);
 					lineList.add(formatLine);
 				}	else {

--- a/src/me/TheTealViper/chatbubbles/implentations/HolographicDisplaysImplementation.java
+++ b/src/me/TheTealViper/chatbubbles/implentations/HolographicDisplaysImplementation.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -20,7 +21,7 @@ import net.md_5.bungee.api.ChatColor;
 
 public class HolographicDisplaysImplementation {
 	public static ChatBubbles plugin;
-	private Map<UUID, List<Hologram>> existingHolograms = new HashMap<UUID, List<Hologram>>();
+	public Map<UUID, List<Hologram>> existingHolograms = new HashMap<UUID, List<Hologram>>();
 
 	public void handleZero(String message, Player p){
 		boolean requirePerm = plugin.getConfig().getBoolean("ConfigZero_Require_Permissions");
@@ -331,12 +332,12 @@ public class HolographicDisplaysImplementation {
 		}
 	}
 	
-	public int formatHologramLines(Player p, Hologram hologram, String message){
+	public int formatHologramLines(LivingEntity e, Hologram hologram, String message){
 		List<String> lineList = new ArrayList<String>();
 		for(String formatLine : plugin.getConfig().getStringList("ChatBubble_Message_Format")){
 			boolean addedToLine = false;
 			if(Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI"))
-				formatLine = placeholderShit.formatString(p, formatLine);
+				formatLine = placeholderShit.formatString(e, formatLine);
 			if(formatLine.contains("%chatbubble_message%")){
 				addedToLine = true;
 				formatLine = formatLine.replace("%chatbubble_message%", message);
@@ -376,7 +377,7 @@ public class HolographicDisplaysImplementation {
 						s = ChatBubbles.makeColors(s);
 						if(plugin.getConfig().getBoolean("ChatBubble_Strip_Formatting"))
 							s = ChatColor.stripColor(s);
-						s = placeholderShit.formatString(p, plugin.prefix + s + plugin.suffix);
+						s = placeholderShit.formatString(e, plugin.prefix + s + plugin.suffix);
 						s = ChatBubbles.makeColors(s);
 						lineList.add(s);
 					} else {
@@ -393,7 +394,7 @@ public class HolographicDisplaysImplementation {
 					formatLine = ChatBubbles.makeColors(formatLine);
 					if(plugin.getConfig().getBoolean("ChatBubble_Strip_Formatting"))
 						formatLine = ChatColor.stripColor(formatLine);
-					formatLine = placeholderShit.formatString(p, plugin.prefix + formatLine + plugin.suffix);
+					formatLine = placeholderShit.formatString(e, plugin.prefix + formatLine + plugin.suffix);
 					formatLine = ChatBubbles.makeColors(formatLine);
 					lineList.add(formatLine);
 				}	else {

--- a/src/me/TheTealViper/chatbubbles/placeholderShit.java
+++ b/src/me/TheTealViper/chatbubbles/placeholderShit.java
@@ -1,11 +1,17 @@
 package me.TheTealViper.chatbubbles;
 
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
 import me.clip.placeholderapi.PlaceholderAPI;
 
 public class placeholderShit {
-	public static String formatString(Player p, String s){
-		return PlaceholderAPI.setPlaceholders(p, s);
+	public static String formatString(LivingEntity e, String s){
+		if(e instanceof Player)
+			return PlaceholderAPI.setPlaceholders((Player)e, s);
+		if(e instanceof OfflinePlayer)
+			return PlaceholderAPI.setPlaceholders((OfflinePlayer)e, s);
+		return PlaceholderAPI.setPlaceholders(null, s);
 	}
 }


### PR DESCRIPTION
This allows someone to set their Citizens based NPC to speak in ChatBubbles when speaking by doing "/trait chatbubble". Citizens support is only loaded when detected to avoid NPEs, and the trait is deregistered properly. Also, Citizens support may be disabled in Config if the player wanted to save resources. I had to rework the formatHologramLines methods slightly to allow LivingEntity instead of Player and expose some methods and variables to make it work. Check it out and thanks for making the plugin! I hope you add the feature so I can dump my other fork :P