### PR TITLE
(fixes #4) add prefix option to not send ChatBubbles

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -9,6 +9,7 @@ ChatBubble_Configuration_Mode: 0
 #3 - Every chat message is visible as a ChatBubble to players in the same Faction
 #4 - Every chat message appears only in text chat like vanilla but still allows a noise to be played
 #5 - Messages starting with ".<message>" become a ChatBubble. Like #1 but quicker.
+#6 - Every message becomes a ChatBubble except for messages starting with "!<message>"
 
 ##############################
 #      Universal Config      #
@@ -152,7 +153,7 @@ ConfigZero_See_Permission: "chatbubble.see"
 #          1 Config          #
 ##############################
 
-#This configuration mode uses "ChatBubble_Send_Original_Message" found in the 
+#This configuration mode uses "ChatBubble_Send_Original_Message" found in the
 #"Universal Config" to determine whether ChatBubble messages also get sent in chat
 
 ConfigOne_Require_Permissions: true
@@ -176,7 +177,7 @@ ConfigTwo_Permission_Groups:
 #          5 Config          #
 ##############################
 
-#This configuration mode uses "ChatBubble_Send_Original_Message" found in the 
+#This configuration mode uses "ChatBubble_Send_Original_Message" found in the
 #"Universal Config" to determine whether ChatBubble messages also get sent in chat
 
 ConfigFive_Require_Permissions: true
@@ -186,9 +187,24 @@ ConfigFive_Use_Permission: "chatbubble.use"
 ConfigFive_See_Permission: "chatbubble.see"
 #This is the permission necessary to see a ChatBubble
 
-ConfigFive_Prefix_Characters: 
+ConfigFive_Prefix_Characters:
  - "."
  - "。"
+
+##############################
+#          6 Config          #
+##############################
+
+ConfigSix_Require_Permissions: true
+#Enabling this requires players to have the permission to get a ChatBubble
+ConfigSix_Use_Permission: "chatbubble.use"
+#This is the permission necessary to get a ChatBubble
+ConfigSix_See_Permission: "chatbubble.see"
+#This is the permission necessary to see a ChatBubble
+
+ConfigSix_Prefix_Characters:
+ - "!"
+
 #This is the character which if ANY message starts with will be turned into a chatbubble.
 #Can be multiple characters long, but was never intended to be used that way.
 #Technically can be used as ANY custom command if set to "/cb" for example but definitely

--- a/src/me/TheTealViper/chatbubbles/ChatBubbles.java
+++ b/src/me/TheTealViper/chatbubbles/ChatBubbles.java
@@ -41,7 +41,7 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 	public DecentHologramsImplementation DHI;
 	public static EventPriority eventPriority;
 	private ChatBubbleTrait trait;
-	
+
 	public void onEnable(){
 		if(Bukkit.getServer().getPluginManager().getPlugin("DecentHolograms") != null) {
 			foundDecentHolograms = true;
@@ -64,10 +64,10 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 				net.citizensnpcs.api.CitizensAPI.getTraitFactory().registerTrait(net.citizensnpcs.api.trait.TraitInfo.create(ChatBubbleTrait.class).withName("chatbubble"));
 				trait = new ChatBubbleTrait();
 				//trait.plugin = this; //Can't do it this way because constructor uses it and I don't know if adding args to constructor will break two lines up trait registration
-			}					
+			}
 		}
 	}
-	
+
 	private void initVars() {
 		life = getConfig().getInt("ChatBubble_Life");
 		distance = getConfig().getInt("ChatBubble_Viewing_Distance");
@@ -82,40 +82,40 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 		bubbleOffset = getConfig().getDouble("ChatBubble_Height_Offset");
 		useTrait = getConfig().getBoolean("Use_ChatBubble_Trait_Citizens");
 		switch(getConfig().getString("ChatBubble_EventPriority").toUpperCase()) {
-		case "HIGH":
-			eventPriority = EventPriority.HIGH;
-			ChatListenerHIGH.plugin = this;
-			Bukkit.getPluginManager().registerEvents(new ChatListenerHIGH(), this);
-			break;
-		case "HIGHEST":
-			eventPriority = EventPriority.HIGHEST;
-			ChatListenerHIGHEST.plugin = this;
-			Bukkit.getPluginManager().registerEvents(new ChatListenerHIGHEST(), this);
-			break;
-		case "LOW":
-			eventPriority = EventPriority.LOW;
-			ChatListenerLOW.plugin = this;
-			Bukkit.getPluginManager().registerEvents(new ChatListenerLOW(), this);
-			break;
-		case "LOWEST":
-			eventPriority = EventPriority.LOWEST;
-			ChatListenerLOWEST.plugin = this;
-			Bukkit.getPluginManager().registerEvents(new ChatListenerLOWEST(), this);
-			break;
-		case "MONITOR":
-			eventPriority = EventPriority.MONITOR;
-			ChatListenerMONITOR.plugin = this;
-			Bukkit.getPluginManager().registerEvents(new ChatListenerMONITOR(), this);
-			break;
-		case "NORMAL":
-			eventPriority = EventPriority.NORMAL;
-			ChatListenerNORMAL.plugin = this;
-			Bukkit.getPluginManager().registerEvents(new ChatListenerNORMAL(), this);
-			break;
+			case "HIGH":
+				eventPriority = EventPriority.HIGH;
+				ChatListenerHIGH.plugin = this;
+				Bukkit.getPluginManager().registerEvents(new ChatListenerHIGH(), this);
+				break;
+			case "HIGHEST":
+				eventPriority = EventPriority.HIGHEST;
+				ChatListenerHIGHEST.plugin = this;
+				Bukkit.getPluginManager().registerEvents(new ChatListenerHIGHEST(), this);
+				break;
+			case "LOW":
+				eventPriority = EventPriority.LOW;
+				ChatListenerLOW.plugin = this;
+				Bukkit.getPluginManager().registerEvents(new ChatListenerLOW(), this);
+				break;
+			case "LOWEST":
+				eventPriority = EventPriority.LOWEST;
+				ChatListenerLOWEST.plugin = this;
+				Bukkit.getPluginManager().registerEvents(new ChatListenerLOWEST(), this);
+				break;
+			case "MONITOR":
+				eventPriority = EventPriority.MONITOR;
+				ChatListenerMONITOR.plugin = this;
+				Bukkit.getPluginManager().registerEvents(new ChatListenerMONITOR(), this);
+				break;
+			case "NORMAL":
+				eventPriority = EventPriority.NORMAL;
+				ChatListenerNORMAL.plugin = this;
+				Bukkit.getPluginManager().registerEvents(new ChatListenerNORMAL(), this);
+				break;
 		}
 		ChatListenerPrototype.RegisterBlacklist(this);
 	}
-	
+
 	public void onDisable(){
 		if(getServer().getPluginManager().getPlugin("Citizens") != null) {
 			if(getServer().getPluginManager().getPlugin("Citizens").isEnabled() && this.useTrait) {
@@ -124,7 +124,7 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 		}
 		getServer().getConsoleSender().sendMessage(makeColors("ChatBubbles from TheTealViper shutting down. Bshzzzzzz"));
 	}
-	
+
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args){
 		if(sender instanceof Player) {
 			Player p = (Player) sender;
@@ -172,12 +172,12 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 		}
 		return false;
 	}
-	
+
 //	@EventHandler
 //	public void onChat(com.palmergames.bukkit.TownyChat.events.AsyncChatHookEvent e) {
 //		e.getChannel().
 //	}
-	
+
 	@EventHandler
 	public void onJoin(PlayerJoinEvent e) {
 		Player p = e.getPlayer();
@@ -186,7 +186,7 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 			togglePF.save();
 		}
 	}
-	
+
 	@EventHandler
 	public void onQuit(PlayerQuitEvent e){
 		if(foundHolographicDisplays)
@@ -194,7 +194,7 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 		else if(foundDecentHolograms)
 			DHI.onQuit(e.getPlayer().getUniqueId());
 	}
-	
+
 	public void handleZero(String message, Player p){
 		Bukkit.getScheduler().scheduleSyncDelayedTask(this, new Runnable() {public void run() {
 			if(foundHolographicDisplays)
@@ -203,7 +203,7 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 				DHI.handleZero(message, p);
 		}}, 0);
 	}
-	
+
 	public void handleOne(String message, Player p){
 		Bukkit.getScheduler().scheduleSyncDelayedTask(this, new Runnable() {public void run() {
 			if(foundHolographicDisplays)
@@ -212,7 +212,7 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 				DHI.handleOne(message, p);
 		}}, 0);
 	}
-	
+
 	public void handleTwo(String message, Player p){
 		Bukkit.getScheduler().scheduleSyncDelayedTask(this, new Runnable() {public void run() {
 			if(foundHolographicDisplays)
@@ -221,7 +221,7 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 				DHI.handleTwo(message, p);
 		}}, 0);
 	}
-	
+
 	public void handleThree(String message, Player p){
 		Bukkit.getScheduler().scheduleSyncDelayedTask(this, new Runnable() {public void run() {
 			if(foundHolographicDisplays)
@@ -230,7 +230,7 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 				DHI.handleThree(message, p);
 		}}, 0);
 	}
-	
+
 	public void handleFour(String message, Player p){
 		Bukkit.getScheduler().scheduleSyncDelayedTask(this, new Runnable() {public void run() {
 			if(foundHolographicDisplays)
@@ -239,7 +239,7 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 				DHI.handleFour(message, p);
 		}}, 0);
 	}
-	
+
 	public void handleFive(String message, Player p){
 		Bukkit.getScheduler().scheduleSyncDelayedTask(this, new Runnable() {public void run() {
 			if(foundHolographicDisplays)
@@ -248,9 +248,18 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 				DHI.handleFive(message, p);
 		}}, 0);
 	}
-	
+
+	public void handleSix(String message, Player p){
+		Bukkit.getScheduler().scheduleSyncDelayedTask(this, new Runnable() {public void run() {
+			if(foundHolographicDisplays)
+				HDI.handleSix(message, p);
+			else if(foundDecentHolograms)
+				DHI.handleSix(message, p);
+		}}, 0);
+	}
+
 //------------------------Utilities--------------------------------
-	
+
 	public final static Pattern HEXPAT = Pattern.compile("&#[a-fA-F0-9]{6}");
 	public static String makeColors(String s){
 		//Handle standard basic colors
@@ -277,13 +286,13 @@ public class ChatBubbles extends JavaPlugin implements Listener{
 		while(s.contains("&o"))s = s.replace("&o", ChatColor.ITALIC + "");
 		while(s.contains("&r"))s = s.replace("&r", ChatColor.RESET + "");
 		//Handle custom hex codes (1.16 and up)
-        Matcher match = HEXPAT.matcher(s);
-        while(match.find()) {
-        	String color = s.substring(match.start(), match.end());
-        	s = s.replace(color, ChatColor.of(color.replace("&", "")) + "");
-        }
-        
+		Matcher match = HEXPAT.matcher(s);
+		while(match.find()) {
+			String color = s.substring(match.start(), match.end());
+			s = s.replace(color, ChatColor.of(color.replace("&", "")) + "");
+		}
+
 		return s;
 	}
-	
+
 }

--- a/src/me/TheTealViper/chatbubbles/implentations/ChatListenerPrototype.java
+++ b/src/me/TheTealViper/chatbubbles/implentations/ChatListenerPrototype.java
@@ -14,7 +14,7 @@ import me.TheTealViper.chatbubbles.thirdparty.RegexpGenerator;
 
 public class ChatListenerPrototype {
 	private static List<Pattern> BlacklistRegexList = new ArrayList<Pattern>();
-	
+
 	public static void RegisterBlacklist (ChatBubbles plugin) {
 		RegexpGenerator RG = new RegexpGenerator();
 		for (String word : plugin.getConfig().getStringList("ChatBubble_Filter_List")) {
@@ -22,7 +22,7 @@ public class ChatListenerPrototype {
 			BlacklistRegexList.add(Pattern.compile(regexStr));
 		}
 	}
-	
+
 	public static void onChat(ChatBubbles plugin, AsyncPlayerChatEvent e) {
 		if(e.isCancelled() || e.getPlayer().getGameMode().name().equals(GameMode.SPECTATOR.name()))
 			return;
@@ -37,84 +37,105 @@ public class ChatListenerPrototype {
 			return;
 		//Handle message
 		switch (plugin.getConfig().getInt("ChatBubble_Configuration_Mode")){
-		case 0:
-			//If player has manually toggled to disable the hologram functionality
-			if(!plugin.togglePF.getBoolean(e.getPlayer().getUniqueId().toString())) return;
-			if(!plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message")) //This MUST be handled here. If handled by manual player.chat() leads to infinite recursion onPlayerChatEvent
-				e.setCancelled(true);
-			plugin.handleZero(messageOverride, e.getPlayer());
-			break;
-		case 1:
-			//This is handled in the command event
-			break;
-		case 2:
-			//If player has manually toggled to disable the hologram functionality
-			if(!plugin.togglePF.getBoolean(e.getPlayer().getUniqueId().toString())) return;
-			if(!plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message")) //This MUST be handled here. If handled by manual player.chat() leads to infinite recursion onPlayerChatEvent
-				e.setCancelled(true);
-			plugin.handleTwo(messageOverride, e.getPlayer());
-			break;
-		case 3:
-			if(Bukkit.getServer().getPluginManager().getPlugin("Factions") != null) {
+			case 0:
 				//If player has manually toggled to disable the hologram functionality
 				if(!plugin.togglePF.getBoolean(e.getPlayer().getUniqueId().toString())) return;
 				if(!plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message")) //This MUST be handled here. If handled by manual player.chat() leads to infinite recursion onPlayerChatEvent
 					e.setCancelled(true);
-				plugin.handleThree(messageOverride, e.getPlayer());
-			}else{
-				plugin.getServer().getConsoleSender().sendMessage("ChatBubbles is set to configuration mode 3 but Factions can't be found!");
-			}
-			break;
-		case 4:
-			//If player has manually toggled to disable the hologram functionality
-			if(!plugin.togglePF.getBoolean(e.getPlayer().getUniqueId().toString())) return;
-			if(!plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message")) //This MUST be handled here. If handled by manual player.chat() leads to infinite recursion onPlayerChatEvent
-				e.setCancelled(true);
-			plugin.handleFour(messageOverride, e.getPlayer());
-			break;
-		case 5:
-			// Find out if message starts with config.yml prefixes, and if so which one
-			List<String> prefixes = plugin.getConfig().getStringList("ConfigFive_Prefix_Characters");
-			String foundPrefix = "";
-			for(String prefix : prefixes) {
-				if(!foundPrefix.equals("")) continue;
-				if(messageOverride.startsWith(prefix)) {
-					foundPrefix = prefix;
+				plugin.handleZero(messageOverride, e.getPlayer());
+				break;
+			case 1:
+				//This is handled in the command event
+				break;
+			case 2:
+				//If player has manually toggled to disable the hologram functionality
+				if(!plugin.togglePF.getBoolean(e.getPlayer().getUniqueId().toString())) return;
+				if(!plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message")) //This MUST be handled here. If handled by manual player.chat() leads to infinite recursion onPlayerChatEvent
+					e.setCancelled(true);
+				plugin.handleTwo(messageOverride, e.getPlayer());
+				break;
+			case 3:
+				if(Bukkit.getServer().getPluginManager().getPlugin("Factions") != null) {
+					//If player has manually toggled to disable the hologram functionality
+					if(!plugin.togglePF.getBoolean(e.getPlayer().getUniqueId().toString())) return;
+					if(!plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message")) //This MUST be handled here. If handled by manual player.chat() leads to infinite recursion onPlayerChatEvent
+						e.setCancelled(true);
+					plugin.handleThree(messageOverride, e.getPlayer());
+				}else{
+					plugin.getServer().getConsoleSender().sendMessage("ChatBubbles is set to configuration mode 3 but Factions can't be found!");
 				}
-			}
-			//If message starts with a prefix
-			if(!foundPrefix.equals("")) {
+				break;
+			case 4:
 				//If player has manually toggled to disable the hologram functionality
 				if(!plugin.togglePF.getBoolean(e.getPlayer().getUniqueId().toString())) return;
 				if(!plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message")) //This MUST be handled here. If handled by manual player.chat() leads to infinite recursion onPlayerChatEvent
 					e.setCancelled(true);
-				e.setMessage(e.getMessage().substring(foundPrefix.length())); //This is uniquely necessary to this config mode 5
-				messageOverride = messageOverride.substring(foundPrefix.length());
-				plugin.handleFive(messageOverride, e.getPlayer());
-			}
-			break;
-		default:
-			break;
+				plugin.handleFour(messageOverride, e.getPlayer());
+				break;
+			case 5:
+				// Find out if message starts with config.yml prefixes, and if so which one
+				List<String> prefixes = plugin.getConfig().getStringList("ConfigFive_Prefix_Characters");
+				String foundPrefix = "";
+				for(String prefix : prefixes) {
+					if(!foundPrefix.equals("")) continue;
+					if(messageOverride.startsWith(prefix)) {
+						foundPrefix = prefix;
+					}
+				}
+				//If message starts with a prefix
+				if(!foundPrefix.equals("")) {
+					//If player has manually toggled to disable the hologram functionality
+					if(!plugin.togglePF.getBoolean(e.getPlayer().getUniqueId().toString())) return;
+					if(!plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message")) //This MUST be handled here. If handled by manual player.chat() leads to infinite recursion onPlayerChatEvent
+						e.setCancelled(true);
+					e.setMessage(e.getMessage().substring(foundPrefix.length())); //This is uniquely necessary to this config mode 5
+					messageOverride = messageOverride.substring(foundPrefix.length());
+					plugin.handleFive(messageOverride, e.getPlayer());
+				}
+				break;
+			case 6:
+				List<String> prefixList = plugin.getConfig().getStringList("ConfigSix_Prefix_Characters");
+				// Check if message is prefixed to not be in ChatBubble
+				String prefix = "";
+				for(String pref : prefixList) {
+					if(!prefix.equals("")) continue;
+					if(messageOverride.startsWith(pref)) {
+						prefix = pref;
+					}
+				}
+				// If the message wasn't prefixed to be ignored, send the ChatBubble
+				if(prefix.equals("")) {
+					//If player has manually toggled to disable the hologram functionality
+					if (!plugin.togglePF.getBoolean(e.getPlayer().getUniqueId().toString())) return;
+					if (!plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message")) //This MUST be handled here. If handled by manual player.chat() leads to infinite recursion onPlayerChatEvent
+						e.setCancelled(true);
+					e.setMessage(e.getMessage().substring(prefix.length())); //This is necessary to remove prefix from message in chat
+					messageOverride = messageOverride.substring(prefix.length());
+					plugin.handleSix(messageOverride, e.getPlayer());
+				}
+				break;
+			default:
+				break;
 		}
 	}
-	
-	
-	
+
+
+
 	public static String replaceBlacklist (String message) {
 		String lowercaseString = message.toLowerCase();
 		String modifiedString = "";
 		int checkpointIndex = 0;
 		for (Pattern p : BlacklistRegexList) {
 			Matcher m = p.matcher(lowercaseString);
-	        while (m.find()) {
-	        	int findStart = m.start();
-	        	int findEnd = m.end();
-	        	modifiedString += message.substring(checkpointIndex, findStart);
-	        	checkpointIndex = findEnd;
-	        }
+			while (m.find()) {
+				int findStart = m.start();
+				int findEnd = m.end();
+				modifiedString += message.substring(checkpointIndex, findStart);
+				checkpointIndex = findEnd;
+			}
 		}
 		modifiedString += message.substring(checkpointIndex, message.length());
 		return modifiedString;
 	}
-	
+
 }

--- a/src/me/TheTealViper/chatbubbles/implentations/DecentHologramsImplementation.java
+++ b/src/me/TheTealViper/chatbubbles/implentations/DecentHologramsImplementation.java
@@ -22,31 +22,31 @@ import net.md_5.bungee.api.ChatColor;
 public class DecentHologramsImplementation {
 	public static ChatBubbles plugin;
 	public Map<UUID, List<Hologram>> existingHolograms = new HashMap<UUID, List<Hologram>>();
-	
+
 	public void handleZero(String message, Player p){
 		handleHologram(message, p, 0);
 	}
-	
+
 	public void handleOne(String message, Player p){
 		handleHologram(message, p, 1);
 	}
-	
+
 	public void handleTwo(String message, Player p){
 		handleHologram(message, p, 2);
 	}
-	
+
 	public void handleThree(String message, Player p){
 		handleHologram(message, p, 3);
 	}
-	
+
 	public void handleFour(String message, Player p){
 		handleHologram(message, p, 4);
 	}
-	
-	public void handleFive(String message, Player p){
-		handleHologram(message, p, 5);
-	}
-	
+
+	public void handleFive(String message, Player p){ handleHologram(message, p, 5); }
+
+	public void handleSix(String message, Player p){ handleHologram(message, p, 6); }
+
 	public int formatHologramLines(LivingEntity e, Hologram hologram, String message){
 		List<String> lineList = new ArrayList<String>();
 		for(String formatLine : plugin.getConfig().getStringList("ChatBubble_Message_Format")){
@@ -58,7 +58,7 @@ public class DecentHologramsImplementation {
 				message = ChatBubbles.makeColors(message);
 				if(plugin.getConfig().getBoolean("ChatBubble_Strip_Formatting"))
 					message = ChatColor.stripColor(message);
-				
+
 				//-----
 				//----- Handle strings wrapping numerous lines -----
 				//-----
@@ -77,29 +77,29 @@ public class DecentHologramsImplementation {
 							period = plugin.length;
 						}
 						StringBuilder builder = new StringBuilder(
-						         s.length() + insert.length() * (s.length()/plugin.length)+1);
+								s.length() + insert.length() * (s.length()/plugin.length)+1);
 
-						    int index = 0;
-						    String prefix = "";
-						    while (index < s.length())
-						    {
-						        // Don't put the insert in the very first iteration.
-						        // This is easier than appending it *after* each substring
-						        builder.append(prefix);
-						        prefix = insert;
-						        builder.append(s.substring(index, 
-						            Math.min(index + period, s.length())));
-						        index += period;
-						    }
+						int index = 0;
+						String prefix = "";
+						while (index < s.length())
+						{
+							// Don't put the insert in the very first iteration.
+							// This is easier than appending it *after* each substring
+							builder.append(prefix);
+							prefix = insert;
+							builder.append(s.substring(index,
+									Math.min(index + period, s.length())));
+							index += period;
+						}
 						String replacement = builder.toString();
 						message = message.replace(s, replacement);
 					}
 				}
-				
+
 				StringBuilder sb = new StringBuilder(formatLine.replace("%chatbubble_message%", message));
 				int i = 0;
 				while (i + plugin.length < sb.length() && (i = sb.lastIndexOf(" ", i + plugin.length)) != -1) {
-				    sb.replace(i, i + 1, "\n");
+					sb.replace(i, i + 1, "\n");
 				}
 				for(String s : sb.toString().split("\\n")){
 					if(Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
@@ -137,11 +137,11 @@ public class DecentHologramsImplementation {
 		//	hologram.appendTextLine(s);
 		return lineList.size();
 	}
-	
+
 	public void onQuit(UUID uuid) {
 		existingHolograms.remove(uuid);
 	}
-	
+
 	public void handleHologram(String message, LivingEntity le, int configMode) {
 		handleHologram(message, le, configMode, "");
 	}
@@ -151,95 +151,104 @@ public class DecentHologramsImplementation {
 		//-----
 		boolean /*sendOriginal = false,*/ isSoundOnly = false, requirePerm = false, citizensShowToAll = false;
 		String permGroup = null, usePerm = null, seePerm = null, factionName = null;
-		
+
 		//-----
 		//----- Initialize Vars -----
 		//-----
 		switch (configMode) {
-		case -1:
-			//This case is for Citizens NPCs
-			//sendOriginal = false; //Setting this false here prevents a potential double message because the NPC chat event isn't cancelled unlike the players'
-			isSoundOnly = false; //Only true for configMode = 4
-			requirePerm = false;
-			citizensShowToAll = true; //Only applicable for configMode = -1
-			permGroup = null; //Only applicable for configMode = 2
-			usePerm = null;
-			seePerm = null;
-			factionName = null; //Only applicable for configMode = 3
-			break;
-		case 0:
-			//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
-			isSoundOnly = false; //Only true for configMode = 4
-			requirePerm = plugin.getConfig().getBoolean("ConfigZero_Require_Permissions");
-			citizensShowToAll = false; //Only applicable for configMode = -1
-			permGroup = null; //Only applicable for configMode = 2
-			usePerm = plugin.getConfig().getString("ConfigZero_Use_Permission");
-			seePerm = plugin.getConfig().getString("ConfigZero_See_Permission");
-			factionName = null; //Only applicable for configMode = 3
-			break;
-		case 1:
-			//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
-			isSoundOnly = false; //Only true for configMode = 4
-			requirePerm = plugin.getConfig().getBoolean("ConfigOne_Require_Permissions");
-			citizensShowToAll = false; //Only applicable for configMode = -1
-			permGroup = null; //Only applicable for configMode = 2
-			usePerm = plugin.getConfig().getString("ConfigOne_Use_Permission");
-			seePerm = plugin.getConfig().getString("ConfigOne_See_Permission");
-			factionName = null; //Only applicable for configMode = 3
-			break;
-		case 2:
-			//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
-			isSoundOnly = false; //Only true for configMode = 4
-			requirePerm = false; //Permission group overrides this
-			citizensShowToAll = false; //Only applicable for configMode = -1
-			permGroup = ""; //null means this is skipped, "" means error & return without creating hologram
-			usePerm = null;
-			seePerm = null;
-			factionName = null; //Only applicable for configMode = 3
-			break;
-		case 3:
-			//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
-			isSoundOnly = false; //Only true for configMode = 4
-			requirePerm = false;
-			citizensShowToAll = false; //Only applicable for configMode = -1
-			permGroup = null; //Only applicable for configMode = 2
-			usePerm = null;
-			seePerm = null;
-			factionName = ""; //null means this is skipped, "" means error & return without creating hologram
-			break;
-		case 4:
-			//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
-			isSoundOnly = true; //Only true for configMode = 4
-			requirePerm = false;
-			citizensShowToAll = false; //Only applicable for configMode = -1
-			permGroup = null; //Only applicable for configMode = 2
-			usePerm = null;
-			seePerm = null;
-			factionName = null; //Only applicable for configMode = 3
-			break;
-		case 5:
-			//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
-			isSoundOnly = false; //Only true for configMode = 4
-			requirePerm = plugin.getConfig().getBoolean("ConfigFive_Require_Permissions");
-			citizensShowToAll = false; //Only applicable for configMode = -1
-			permGroup = null; //Only applicable for configMode = 2
-			usePerm = plugin.getConfig().getString("ConfigFive_Use_Permission");
-			seePerm = plugin.getConfig().getString("ConfigFive_See_Permission");
-			factionName = null; //Only applicable for configMode = 3
-			break;
-		default:
-			//Copy of case 0
-			//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
-			isSoundOnly = false; //Only true for configMode = 4
-			requirePerm = plugin.getConfig().getBoolean("ConfigZero_Require_Permissions");
-			citizensShowToAll = false; //Only applicable for configMode = -1
-			permGroup = null; //Only applicable for configMode = 2
-			usePerm = plugin.getConfig().getString("ConfigZero_Use_Permission");
-			seePerm = plugin.getConfig().getString("ConfigZero_See_Permission");
-			factionName = null; //Only applicable for configMode = 3
-			break;
+			case -1:
+				//This case is for Citizens NPCs
+				//sendOriginal = false; //Setting this false here prevents a potential double message because the NPC chat event isn't cancelled unlike the players'
+				isSoundOnly = false; //Only true for configMode = 4
+				requirePerm = false;
+				citizensShowToAll = true; //Only applicable for configMode = -1
+				permGroup = null; //Only applicable for configMode = 2
+				usePerm = null;
+				seePerm = null;
+				factionName = null; //Only applicable for configMode = 3
+				break;
+			case 0:
+				//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
+				isSoundOnly = false; //Only true for configMode = 4
+				requirePerm = plugin.getConfig().getBoolean("ConfigZero_Require_Permissions");
+				citizensShowToAll = false; //Only applicable for configMode = -1
+				permGroup = null; //Only applicable for configMode = 2
+				usePerm = plugin.getConfig().getString("ConfigZero_Use_Permission");
+				seePerm = plugin.getConfig().getString("ConfigZero_See_Permission");
+				factionName = null; //Only applicable for configMode = 3
+				break;
+			case 1:
+				//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
+				isSoundOnly = false; //Only true for configMode = 4
+				requirePerm = plugin.getConfig().getBoolean("ConfigOne_Require_Permissions");
+				citizensShowToAll = false; //Only applicable for configMode = -1
+				permGroup = null; //Only applicable for configMode = 2
+				usePerm = plugin.getConfig().getString("ConfigOne_Use_Permission");
+				seePerm = plugin.getConfig().getString("ConfigOne_See_Permission");
+				factionName = null; //Only applicable for configMode = 3
+				break;
+			case 2:
+				//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
+				isSoundOnly = false; //Only true for configMode = 4
+				requirePerm = false; //Permission group overrides this
+				citizensShowToAll = false; //Only applicable for configMode = -1
+				permGroup = ""; //null means this is skipped, "" means error & return without creating hologram
+				usePerm = null;
+				seePerm = null;
+				factionName = null; //Only applicable for configMode = 3
+				break;
+			case 3:
+				//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
+				isSoundOnly = false; //Only true for configMode = 4
+				requirePerm = false;
+				citizensShowToAll = false; //Only applicable for configMode = -1
+				permGroup = null; //Only applicable for configMode = 2
+				usePerm = null;
+				seePerm = null;
+				factionName = ""; //null means this is skipped, "" means error & return without creating hologram
+				break;
+			case 4:
+				//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
+				isSoundOnly = true; //Only true for configMode = 4
+				requirePerm = false;
+				citizensShowToAll = false; //Only applicable for configMode = -1
+				permGroup = null; //Only applicable for configMode = 2
+				usePerm = null;
+				seePerm = null;
+				factionName = null; //Only applicable for configMode = 3
+				break;
+			case 5:
+				//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
+				isSoundOnly = false; //Only true for configMode = 4
+				requirePerm = plugin.getConfig().getBoolean("ConfigFive_Require_Permissions");
+				citizensShowToAll = false; //Only applicable for configMode = -1
+				permGroup = null; //Only applicable for configMode = 2
+				usePerm = plugin.getConfig().getString("ConfigFive_Use_Permission");
+				seePerm = plugin.getConfig().getString("ConfigFive_See_Permission");
+				factionName = null; //Only applicable for configMode = 3
+				break;
+			case 6:
+				isSoundOnly = false; //Only true for configMode = 4
+				requirePerm = plugin.getConfig().getBoolean("ConfigSix_Require_Permissions");
+				citizensShowToAll = false; //Only applicable for configMode = -1
+				permGroup = null; //Only applicable for configMode = 2
+				usePerm = plugin.getConfig().getString("ConfigSix_Use_Permission");
+				seePerm = plugin.getConfig().getString("ConfigSix_See_Permission");
+				factionName = null; //Only applicable for configMode = 3
+				break;
+			default:
+				//Copy of case 0
+				//sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message"); //Must be handled within ChatListenerPrototype bc infinite recursion
+				isSoundOnly = false; //Only true for configMode = 4
+				requirePerm = plugin.getConfig().getBoolean("ConfigZero_Require_Permissions");
+				citizensShowToAll = false; //Only applicable for configMode = -1
+				permGroup = null; //Only applicable for configMode = 2
+				usePerm = plugin.getConfig().getString("ConfigZero_Use_Permission");
+				seePerm = plugin.getConfig().getString("ConfigZero_See_Permission");
+				factionName = null; //Only applicable for configMode = 3
+				break;
 		}
-		
+
 		//-----
 		//----- Begin Hologram Creation Checks -----
 		//-----
@@ -271,7 +280,7 @@ public class DecentHologramsImplementation {
 		}
 		//Config Mode 3 - If isSoundOnly, we are done here
 		if (isSoundOnly) return;
-		
+
 		//-----
 		//----- Create/Manage Hologram -----
 		//-----
@@ -296,7 +305,7 @@ public class DecentHologramsImplementation {
 					&& (factionName == null || MPlayer.get(oP).getFactionName().equals(factionName)) //A faction isn't intended, or it is and the player is in it : Config Mode 3
 					&& (le instanceof Player && oP.canSee((Player) le))) //Players corporeal bodies are able to see eachother : Config Mode ALL
 				hologram.show(oP, 0);
-				//hologram.getVisibilityManager().showTo(oP);
+			//hologram.getVisibilityManager().showTo(oP);
 		}
 		//Maintain hologram position and kill when time comes
 		int lines = formatHologramLines(le, hologram, message);
@@ -312,7 +321,7 @@ public class DecentHologramsImplementation {
 					hologram.delete();
 					cancel();
 				}
-		}}.runTaskTimer(plugin, 1L, 1L);
+			}}.runTaskTimer(plugin, 1L, 1L);
 	}
-	
+
 }

--- a/src/me/TheTealViper/chatbubbles/implentations/HolographicDisplaysImplementation.java
+++ b/src/me/TheTealViper/chatbubbles/implentations/HolographicDisplaysImplementation.java
@@ -42,9 +42,9 @@ public class HolographicDisplaysImplementation {
 		existingHolograms.put(p.getUniqueId(), hList);
 		hologram.getVisibilityManager().setVisibleByDefault(false);
 		for(Player oP : Bukkit.getOnlinePlayers()){
-			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName())) 
-					&& (oP.getWorld().getName().equals(p.getWorld().getName()) 
-					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance) 
+			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName()))
+					&& (oP.getWorld().getName().equals(p.getWorld().getName())
+					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance)
 					&& (!requirePerm || (requirePerm && oP.hasPermission(seePerm)))
 					&& oP.canSee(p))
 				hologram.getVisibilityManager().showTo(oP);
@@ -62,8 +62,8 @@ public class HolographicDisplaysImplementation {
 					hologram.delete();
 					cancel();
 				}
-		}}.runTaskTimer(plugin, 1L, 1L);
-		
+			}}.runTaskTimer(plugin, 1L, 1L);
+
 		if(plugin.getConfig().getBoolean("ChatBubble_Play_Sound")) {
 			String sound = plugin.getConfig().getString("ChatBubble_Sound_Name").toLowerCase();
 			float volume = (float) plugin.getConfig().getDouble("ChatBubble_Sound_Volume");
@@ -77,7 +77,7 @@ public class HolographicDisplaysImplementation {
 			}
 		}
 	}
-	
+
 	public void handleOne(String message, Player p){
 		boolean sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message");
 		boolean requirePerm = plugin.getConfig().getBoolean("ConfigOne_Require_Permissions");
@@ -97,9 +97,9 @@ public class HolographicDisplaysImplementation {
 		existingHolograms.put(p.getUniqueId(), hList);
 		hologram.getVisibilityManager().setVisibleByDefault(false);
 		for(Player oP : Bukkit.getOnlinePlayers()){
-			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName())) 
-					&& (oP.getWorld().getName().equals(p.getWorld().getName()) 
-					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance) 
+			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName()))
+					&& (oP.getWorld().getName().equals(p.getWorld().getName())
+					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance)
 					&& (!requirePerm || (requirePerm && oP.hasPermission(seePerm)))
 					&& oP.canSee(p))
 				hologram.getVisibilityManager().showTo(oP);
@@ -119,8 +119,8 @@ public class HolographicDisplaysImplementation {
 					hologram.delete();
 					cancel();
 				}
-		}}.runTaskTimer(plugin, 1L, 1L);
-		
+			}}.runTaskTimer(plugin, 1L, 1L);
+
 		if(plugin.getConfig().getBoolean("ChatBubble_Play_Sound")) {
 			String sound = plugin.getConfig().getString("ChatBubble_Sound_Name").toLowerCase();
 			float volume = (float) plugin.getConfig().getDouble("ChatBubble_Sound_Volume");
@@ -134,7 +134,7 @@ public class HolographicDisplaysImplementation {
 			}
 		}
 	}
-	
+
 	public void handleTwo(String message, Player p){
 		boolean sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message");
 		if(existingHolograms.containsKey(p.getUniqueId())) {
@@ -158,9 +158,9 @@ public class HolographicDisplaysImplementation {
 		existingHolograms.put(p.getUniqueId(), hList);
 		hologram.getVisibilityManager().setVisibleByDefault(false);
 		for(Player oP : Bukkit.getOnlinePlayers()){
-			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName())) 
-					&& (oP.getWorld().getName().equals(p.getWorld().getName()) 
-					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance) 
+			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName()))
+					&& (oP.getWorld().getName().equals(p.getWorld().getName())
+					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance)
 					&& (oP.hasPermission(permGroup))
 					&& oP.canSee(p))
 				hologram.getVisibilityManager().showTo(oP);
@@ -180,8 +180,8 @@ public class HolographicDisplaysImplementation {
 					hologram.delete();
 					cancel();
 				}
-		}}.runTaskTimer(plugin, 1L, 1L);
-		
+			}}.runTaskTimer(plugin, 1L, 1L);
+
 		if(plugin.getConfig().getBoolean("ChatBubble_Play_Sound")) {
 			String sound = plugin.getConfig().getString("ChatBubble_Sound_Name").toLowerCase();
 			float volume = (float) plugin.getConfig().getDouble("ChatBubble_Sound_Volume");
@@ -195,7 +195,7 @@ public class HolographicDisplaysImplementation {
 			}
 		}
 	}
-	
+
 	public void handleThree(String message, Player p){
 		boolean sendOriginal = plugin.getConfig().getBoolean("ChatBubble_Send_Original_Message");
 		if(existingHolograms.containsKey(p.getUniqueId())) {
@@ -212,9 +212,9 @@ public class HolographicDisplaysImplementation {
 		existingHolograms.put(p.getUniqueId(), hList);
 		hologram.getVisibilityManager().setVisibleByDefault(false);
 		for(Player oP : Bukkit.getOnlinePlayers()){
-			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName())) 
-					&& (oP.getWorld().getName().equals(p.getWorld().getName()) 
-					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance) 
+			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName()))
+					&& (oP.getWorld().getName().equals(p.getWorld().getName())
+					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance)
 					&& (MPlayer.get(oP).getFactionName().equals(faction))
 					&& oP.canSee(p))
 				hologram.getVisibilityManager().showTo(oP);
@@ -234,8 +234,8 @@ public class HolographicDisplaysImplementation {
 					hologram.delete();
 					cancel();
 				}
-		}}.runTaskTimer(plugin, 1L, 1L);
-		
+			}}.runTaskTimer(plugin, 1L, 1L);
+
 		if(plugin.getConfig().getBoolean("ChatBubble_Play_Sound")) {
 			String sound = plugin.getConfig().getString("ChatBubble_Sound_Name").toLowerCase();
 			float volume = (float) plugin.getConfig().getDouble("ChatBubble_Sound_Volume");
@@ -249,7 +249,7 @@ public class HolographicDisplaysImplementation {
 			}
 		}
 	}
-	
+
 	public void handleFour(String message, Player p){
 		if(plugin.getConfig().getBoolean("ChatBubble_Play_Sound")) {
 			String sound = plugin.getConfig().getString("ChatBubble_Sound_Name").toLowerCase();
@@ -264,7 +264,7 @@ public class HolographicDisplaysImplementation {
 			}
 		}
 	}
-	
+
 	public void handleFive(String message, Player p){
 		boolean sendOriginal = false;
 		boolean requirePerm = plugin.getConfig().getBoolean("ConfigFive_Require_Permissions");
@@ -284,9 +284,9 @@ public class HolographicDisplaysImplementation {
 		existingHolograms.put(p.getUniqueId(), hList);
 		hologram.getVisibilityManager().setVisibleByDefault(false);
 		for(Player oP : Bukkit.getOnlinePlayers()){
-			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName())) 
-					&& (oP.getWorld().getName().equals(p.getWorld().getName()) 
-					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance) 
+			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName()))
+					&& (oP.getWorld().getName().equals(p.getWorld().getName())
+					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance)
 					&& (!requirePerm || (requirePerm && oP.hasPermission(seePerm)))
 					&& oP.canSee(p))
 				hologram.getVisibilityManager().showTo(oP);
@@ -306,8 +306,8 @@ public class HolographicDisplaysImplementation {
 					hologram.delete();
 					cancel();
 				}
-		}}.runTaskTimer(plugin, 1L, 1L);
-		
+			}}.runTaskTimer(plugin, 1L, 1L);
+
 		if(plugin.getConfig().getBoolean("ChatBubble_Play_Sound")) {
 			String sound = plugin.getConfig().getString("ChatBubble_Sound_Name").toLowerCase();
 			float volume = (float) plugin.getConfig().getDouble("ChatBubble_Sound_Volume");
@@ -321,7 +321,61 @@ public class HolographicDisplaysImplementation {
 			}
 		}
 	}
-	
+
+	public void handleSix(String message, Player p){
+		boolean requirePerm = plugin.getConfig().getBoolean("ConfigSix_Require_Permissions");
+		String usePerm = plugin.getConfig().getString("ConfigSix_Use_Permission");
+		String seePerm = plugin.getConfig().getString("ConfigSix_See_Permission");
+		if(requirePerm && !p.hasPermission(usePerm))
+			return;
+		if(existingHolograms.containsKey(p.getUniqueId())) {
+			for(Hologram h : existingHolograms.get(p.getUniqueId())) {
+				if(!h.isDeleted())
+					h.delete();
+			}
+		}
+		final Hologram hologram = HologramsAPI.createHologram(plugin, p.getLocation().add(0.0, plugin.bubbleOffset, 0.0));
+		List<Hologram> hList = new ArrayList<Hologram>();
+		hList.add(hologram);
+		existingHolograms.put(p.getUniqueId(), hList);
+		hologram.getVisibilityManager().setVisibleByDefault(false);
+		for(Player oP : Bukkit.getOnlinePlayers()){
+			if(((plugin.seeOwnBubble) || (!plugin.seeOwnBubble && oP.getName() != p.getName()))
+					&& (oP.getWorld().getName().equals(p.getWorld().getName())
+					&& oP.getLocation().distance(p.getLocation()) <= plugin.distance)
+					&& (!requirePerm || (requirePerm && oP.hasPermission(seePerm)))
+					&& oP.canSee(p))
+				hologram.getVisibilityManager().showTo(oP);
+		}
+		int lines = formatHologramLines(p, hologram, message);
+
+		new BukkitRunnable() {
+			int ticksRun = 0;
+			@Override
+			public void run() {
+				ticksRun++;
+				if(!hologram.isDeleted())
+					hologram.teleport(p.getLocation().add(0.0, plugin.bubbleOffset + .25 * lines, 0.0));
+				if (ticksRun > plugin.life) {
+					hologram.delete();
+					cancel();
+				}
+			}}.runTaskTimer(plugin, 1L, 1L);
+
+		if(plugin.getConfig().getBoolean("ChatBubble_Play_Sound")) {
+			String sound = plugin.getConfig().getString("ChatBubble_Sound_Name").toLowerCase();
+			float volume = (float) plugin.getConfig().getDouble("ChatBubble_Sound_Volume");
+			if(!sound.equals("")) {
+				try {
+					p.getWorld().playSound(p.getLocation(), sound, volume, 1.0f);
+				}catch(Exception e) {
+					plugin.getServer().getConsoleSender().sendMessage("Something is wrong in your ChatBubble config.yml sound settings!");
+					plugin.getServer().getConsoleSender().sendMessage("Please ensure that 'ChatBubble_Sound_Name' works in a '/playsound' command test.");
+				}
+			}
+		}
+	}
+
 	public int formatHologramLines(LivingEntity e, Hologram hologram, String message){
 		List<String> lineList = new ArrayList<String>();
 		for(String formatLine : plugin.getConfig().getStringList("ChatBubble_Message_Format")){
@@ -333,7 +387,7 @@ public class HolographicDisplaysImplementation {
 				message = ChatBubbles.makeColors(message);
 				if(plugin.getConfig().getBoolean("ChatBubble_Strip_Formatting"))
 					message = ChatColor.stripColor(message);
-				
+
 				//-----
 				//----- Handle strings wrapping numerous lines -----
 				//-----
@@ -352,29 +406,29 @@ public class HolographicDisplaysImplementation {
 							period = plugin.length;
 						}
 						StringBuilder builder = new StringBuilder(
-						         s.length() + insert.length() * (s.length()/plugin.length)+1);
+								s.length() + insert.length() * (s.length()/plugin.length)+1);
 
-						    int index = 0;
-						    String prefix = "";
-						    while (index < s.length())
-						    {
-						        // Don't put the insert in the very first iteration.
-						        // This is easier than appending it *after* each substring
-						        builder.append(prefix);
-						        prefix = insert;
-						        builder.append(s.substring(index, 
-						            Math.min(index + period, s.length())));
-						        index += period;
-						    }
+						int index = 0;
+						String prefix = "";
+						while (index < s.length())
+						{
+							// Don't put the insert in the very first iteration.
+							// This is easier than appending it *after* each substring
+							builder.append(prefix);
+							prefix = insert;
+							builder.append(s.substring(index,
+									Math.min(index + period, s.length())));
+							index += period;
+						}
 						String replacement = builder.toString();
 						message = message.replace(s, replacement);
 					}
 				}
-				
+
 				StringBuilder sb = new StringBuilder(formatLine.replace("%chatbubble_message%", message));
 				int i = 0;
 				while (i + plugin.length < sb.length() && (i = sb.lastIndexOf(" ", i + plugin.length)) != -1) {
-				    sb.replace(i, i + 1, "\n");
+					sb.replace(i, i + 1, "\n");
 				}
 				for(String s : sb.toString().split("\\n")){
 					if(Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
@@ -411,9 +465,9 @@ public class HolographicDisplaysImplementation {
 			hologram.appendTextLine(s);
 		return lineList.size();
 	}
-	
+
 	public void onQuit(UUID uuid) {
 		existingHolograms.remove(uuid);
 	}
-	
+
 }


### PR DESCRIPTION
This PR includes another configuration option that is similar to option 5.

It will send all messages as ChatBubbles excluding the ones that are prefixed with !.