### PR TITLE
fix invalid hologram name when using geyser

### DIFF
--- a/src/me/TheTealViper/chatbubbles/implentations/DecentHologramsImplementation.java
+++ b/src/me/TheTealViper/chatbubbles/implentations/DecentHologramsImplementation.java
@@ -289,7 +289,8 @@ public class DecentHologramsImplementation {
 		//----- Create/Manage Hologram -----
 		//-----
 		//Create hologram and input into database
-		final Hologram hologram = DHAPI.createHologram(System.currentTimeMillis() + le.getName() + "", le.getLocation().add(0.0, plugin.bubbleOffset, 0.0));
+		String sanitizedName = le.getName().replaceAll("[^a-zA-Z0-9-_]", "");
+		final Hologram hologram = DHAPI.createHologram(System.currentTimeMillis() + sanitizedName + "", le.getLocation().add(0.0, plugin.bubbleOffset, 0.0));
 		hologram.enable();
 		List<Hologram> hList = new ArrayList<Hologram>();
 		hList.add(hologram);


### PR DESCRIPTION
Geyser prefixes player names with symbols to distinguish Bedrock and Java players. This leads to exceptions when holograms are created that include the players name in their name.

<img width="952" alt="Screenshot 2023-08-14 at 8 48 55 PM" src="https://github.com/thetealviper/Spigot_ChatBubbles/assets/71307091/2855041d-3274-487e-8138-277be5ea67bd">
